### PR TITLE
 feat: Migrate to gitignore from glob 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["regex", "glob", "pattern", "walk", "iterator"]
 
 [dependencies]
 walkdir = "2"
-globset = "0.2"
+ignore = "0.4"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/README.md
+++ b/README.md
@@ -28,16 +28,14 @@ globwalk = "0.1"
 
 The following piece of code recursively find all mp3 and FLAC files:
 
-```rust
+```rust,no_run
 extern crate globwalk;
-use globwalk::GlobWalker;
 
-fn search_and_destroy() {
-    for track in GlobWalker::new("**/*.{mp3,flac}").unwrap() {
-        if let Ok(track) = track {
-            // Destroy satanic rhythms
-            std::fs::remove_file(track.path());
-        } 
+use std::fs;
+
+for img in globwalk::glob("*.{png,jpg,gif}").unwrap() {
+    if let Ok(img) = img {
+        fs::remove_file(img.path()).unwrap();
     }
 }
 ```
@@ -45,21 +43,18 @@ fn search_and_destroy() {
 
 ### Example: Tweak walk options
 
-```rust
+```rust,no_run
 extern crate globwalk;
-use globwalk::GlobWalker;
 
-fn search_and_destroy() {
-    let walker = GlobWalker::new("**/*.{mp3,flac}")
-                    .unwrap()
-                    .max_depth(4)
-                    .follow_links(true)
-                    .into_iter()
-                    .filter_map(Result::ok);
-                    
-    for track in walker {
-        // Destroy symbolic satanic rhythms, but do not stray far.
-        std::fs::remove_file(track.path()); 
-    }
+use std::fs;
+
+let walker = globwalk::glob("*.{png,jpg,gif}")
+    .unwrap()
+    .max_depth(4)
+    .follow_links(true)
+    .into_iter()
+    .filter_map(Result::ok);
+for img in walker {
+    fs::remove_file(img.path()).unwrap();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # GlobWalk #
-A cross platform crate for recursively walking over paths matching a Glob pattern.
+Recursively find files in a directory using globs.
 
-Based on both `walkdir` &️ `globset` (❤), this crate inherits many goodies from both, such as limiting search depth and amount of open file descriptors. 
+Based on both `walkdir` &️ `globset` (❤), this crate inherits many goodies from
+both, such as limiting search depth and amount of open file descriptors.
 
 Licensed under MIT.
 
@@ -9,6 +10,7 @@ Licensed under MIT.
 
  - The `glob` crate does not support having `{a,b}` in patterns.
  - `globwalk` can match several glob-patterns at the same time.
+ - `globwalk` supports excluding results with `!`.
  - `glob` searches for files in the current working directory, whereas `globwalk` starts at a specified base-dir.
 
 ### Documentation ###

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,10 @@ impl Iterator for IntoIter {
     }
 }
 
+/// Construct a new `GlobWalker` with a glob pattern.
+///
+/// When iterated, the current directory will be recursively searched for paths
+/// matching `pattern`.
 pub fn glob<S: AsRef<str>>(pattern: S) -> Result<GlobWalker, GlobError> {
     GlobWalker::new(".", pattern)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,14 @@
 //!
 //! # Example: Finding image files in the current directory.
 //!
-//! ```ignore
-//! for img in GlobWalker::from_patterns(&["*.{png,jpg,gif}"], ".") {
+//! ```no_run
+//! extern crate globwalk;
+//!
+//! use std::fs;
+//!
+//! for img in globwalk::glob("*.{png,jpg,gif}").unwrap() {
 //!     if let Ok(img) = img {
-//!         remove_file(img.path()).unwrap();
+//!         fs::remove_file(img.path()).unwrap();
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,44 +303,22 @@ mod tests {
     }
 
     #[test]
-    fn do_the_globwalk() {
+    fn test_new() {
         let dir = TempDir::new("globset_walkdir").expect("Failed to create temporary folder");
         let dir_path = dir.path();
-        create_dir_all(dir_path.join("src/some_mod")).expect("");
-        create_dir_all(dir_path.join("tests")).expect("");
-        create_dir_all(dir_path.join("contrib")).expect("");
 
         touch(&dir, &[
             "a.rs",
-            "b.rs",
-            "avocado.rs",
-            "lib.c",
-            "src[/]hello.rs",
-            "src[/]world.rs",
-            "src[/]some_mod[/]unexpected.rs",
-            "src[/]cruel.txt",
-            "contrib[/]README.md",
-            "contrib[/]README.rst",
-            "contrib[/]lib.rs",
+            "a.jpg",
+            "a.png",
+            "b.docx",
         ][..]);
 
 
-        let mut builder = GlobSetBuilder::new();
-        builder.add(Glob::new("src/**/*.rs").unwrap());
-        builder.add(Glob::new("*.c").unwrap());
-        builder.add(Glob::new("**/lib.rs").unwrap());
-        builder.add(Glob::new("**/*.{md,rst}").unwrap());
-        let set = builder.build().unwrap();
+        let mut expected = vec!["a.jpg", "a.png"];
 
-        let mut expected: Vec<_> = ["src[/]some_mod[/]unexpected.rs",
-                                    "src[/]world.rs",
-                                    "src[/]hello.rs",
-                                    "lib.c",
-                                    "contrib[/]lib.rs",
-                                    "contrib[/]README.md",
-                                    "contrib[/]README.rst"].iter().map(normalize_path_sep).collect();
-
-        for matched_file in GlobWalker::from_globset(set)
+        for matched_file in GlobWalker::new("*.{png,jpg,gif}")
+                                        .unwrap()
                                         .base_dir(dir_path)
                                         .into_iter()
                                         .filter_map(Result::ok) {
@@ -362,21 +340,38 @@ mod tests {
     }
 
     #[test]
-    fn find_image_files() {
+    fn test_from_patterns() {
         let dir = TempDir::new("globset_walkdir").expect("Failed to create temporary folder");
         let dir_path = dir.path();
+        create_dir_all(dir_path.join("src/some_mod")).expect("");
+        create_dir_all(dir_path.join("tests")).expect("");
+        create_dir_all(dir_path.join("contrib")).expect("");
 
         touch(&dir, &[
             "a.rs",
-            "a.jpg",
-            "a.png",
-            "b.docx",
+            "b.rs",
+            "avocado.rs",
+            "lib.c",
+            "src[/]hello.rs",
+            "src[/]world.rs",
+            "src[/]some_mod[/]unexpected.rs",
+            "src[/]cruel.txt",
+            "contrib[/]README.md",
+            "contrib[/]README.rst",
+            "contrib[/]lib.rs",
         ][..]);
 
 
-        let mut expected = vec!["a.jpg", "a.png"];
+        let mut expected: Vec<_> = ["src[/]some_mod[/]unexpected.rs",
+                                    "src[/]world.rs",
+                                    "src[/]hello.rs",
+                                    "lib.c",
+                                    "contrib[/]lib.rs",
+                                    "contrib[/]README.md",
+                                    "contrib[/]README.rst"].iter().map(normalize_path_sep).collect();
 
-        for matched_file in GlobWalker::new("*.{png,jpg,gif}")
+        let patterns = ["src/**/*.rs", "*.c", "**/lib.rs", "**/*.{md,rst}"];
+        for matched_file in GlobWalker::from_patterns(&patterns)
                                         .unwrap()
                                         .base_dir(dir_path)
                                         .into_iter()


### PR DESCRIPTION
This change switches `globwalk` from basic glob syntax to using
gitignore syntax.

Benefits include
- Excluding content from being walked using `!`
- Controlling for depth with a leading `/`

Fixes #3 

BREAKING CHANGES:
- API: `GlobWalk::new` and `GlobWalk::from_patterns` now accept the
  `base_dir` parameter again.
- Syntax: Some characters are now reserved for gitignore syntax.