### PR TITLE
chore: Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,21 @@ rust:
 matrix:
   include:
   - env: RUSTFMT
-    rust: 1.25.0  # `stable`: Locking down for consistent behavior
+    rust: 1.27.0  # `stable`: Locking down for consistent behavior
     install:
     - rustup component add rustfmt-preview
     script:
     - cargo fmt -- --write-mode=diff
   - env: RUSTFLAGS="-D warnings"
-    rust: 1.25.0  # `stable`: Locking down for consistent behavior
+    rust: 1.27.0  # `stable`: Locking down for consistent behavior
     script:
     - cargo check --tests
-  - env: CLIPPY_VERSION=0.0.179
-    rust: nightly-2018-01-12
+  - env: CLIPPY
+    rust: nightly-2018-07-17
     install:
-    - travis_wait cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
+      - rustup component add clippy-preview
     script:
-    - cargo clippy -- -D clippy
+      - cargo clippy --all-features -- -D clippy
   allow_failures:
     - rust: nightly
   fast_finish: true


### PR DESCRIPTION
I'm seeing failures with other crates due to clippy.  I think the preview somehow broke things.