### PR TITLE
 fix: Re-export DirEntry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,12 +112,16 @@ use ignore::overrides::{Override, OverrideBuilder};
 use ignore::Match;
 use std::cmp::Ordering;
 use std::path::Path;
-use walkdir::{DirEntry, WalkDir};
+use walkdir::WalkDir;
 
 /// Error from parsing globs.
 pub type GlobError = ignore::Error;
 /// Error from iterating on files.
 pub type WalkError = walkdir::Error;
+/// A directory entry.
+///
+/// This is the type of value that is yielded from the iterators defined in this crate.
+pub type DirEntry = walkdir::DirEntry;
 
 /// An iterator for recursively yielding glob matches.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@
 //! # fn main() { run().unwrap() }
 //! ```
 
+#![warn(missing_docs)]
+
 extern crate ignore;
 extern crate walkdir;
 


### PR DESCRIPTION
This ensures `globwalk`'s entire API is accessible without adding extra
dependencies.

This re-enforces that `globwalk`'s public API is tied to `walkdir`.

Fixes #16