### PR TITLE
Bump dependencies to make it build with minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ appveyor  = { repository = "Gilnaa/globwalk" }
 
 [dependencies]
 walkdir = "2"
-ignore = "0.4.6"
+ignore = "0.4.11"
 bitflags = "1.2"
 
 [dev-dependencies]
-tempdir = "0.3"
-docmatic = "0.1"
+tempdir = "0.3.6"
+docmatic = "0.1.2"
 
 # We're not using backtrace, really. It is just a deep dependency of docmatic.
 # Locking down its version so that we can compile the tests using rustc 1.31.0


### PR DESCRIPTION
Some dependencies are too old and does not compile with the minimal versions (generatable by `cargo +nightly update -Z minimal-versions`).
This means that the crate can fail to compile even if all dependencies satisfies versions specified by Cargo.toml.

This commit bumps patch versions of dependencies to make the crate build with the minimal versions.
Tested with rustc 1.48.0.

I think this would be non-breaking change since only patch versions are bumped, but I didn't verified that.

<details>
<summary>build failure withouth this patch</summary>

Result might be different on other machines, due to parallel build and nested dependencies.

```
$ cargo +nightly update -Z minimal-versions && cargo check --all-features
    Updating crates.io index
    Updating aho-corasick v0.7.15 -> v0.6.8
      Adding arrayvec v0.4.0
    Removing autocfg v1.0.1
    Updating backtrace-sys v0.1.37 -> v0.1.17
    Updating bitflags v1.2.1 -> v1.2.0
    Removing bstr v0.2.14
    Updating cc v1.0.66 -> v1.0.0
    Removing cfg-if v0.1.10
    Removing cfg-if v1.0.0
      Adding cfg-if v0.1.6
      Adding cloudabi v0.0.3
      Adding crossbeam-channel v0.3.3
      Adding crossbeam-epoch v0.6.0
    Removing crossbeam-utils v0.8.1
      Adding crossbeam-utils v0.5.0
      Adding crossbeam-utils v0.6.0
    Updating docmatic v0.1.2 -> v0.1.1
    Updating failure v0.1.8 -> v0.1.1
      Adding failure_derive v0.1.1
    Updating fnv v1.0.7 -> v1.0.6
    Removing fuchsia-cprng v0.1.1
      Adding fuchsia-zircon v0.3.2
      Adding fuchsia-zircon-sys v0.3.2
      Adding glob v0.2.0
    Updating globset v0.4.6 -> v0.4.2
    Updating ignore v0.4.17 -> v0.4.6
    Updating lazy_static v1.4.0 -> v1.1.0
    Updating libc v0.2.80 -> v0.2.45
      Adding lock_api v0.1.0
    Updating log v0.4.11 -> v0.4.5
    Updating memchr v2.3.4 -> v2.0.2
      Adding memoffset v0.2.0
      Adding nodrop v0.1.8
      Adding odds v0.2.23
      Adding owning_ref v0.3.0
      Adding parking_lot v0.7.0
      Adding parking_lot_core v0.4.0
      Adding quote v0.3.15
    Removing rand v0.4.6
      Adding rand v0.1.1
      Adding rand v0.6.0
      Adding rand_chacha v0.1.0
    Removing rand_core v0.3.1
    Removing rand_core v0.4.2
      Adding rand_core v0.2.0
      Adding rand_core v0.3.0
      Adding rand_hc v0.1.0
      Adding rand_isaac v0.1.0
      Adding rand_pcg v0.1.0
      Adding rand_xorshift v0.1.0
    Removing rdrand v0.4.0
    Updating regex v1.4.2 -> v1.0.5
    Updating regex-syntax v0.6.21 -> v0.6.2
    Removing remove_dir_all v0.5.3
    Updating rustc-demangle v0.1.18 -> v0.1.4
      Adding rustc_version v0.2.0
    Updating same-file v1.0.6 -> v1.0.3
      Adding scopeguard v0.3.1
      Adding semver v0.6.0
      Adding semver-parser v0.7.0
      Adding smallvec v0.6.10
      Adding syn v0.11.11
      Adding synom v0.11.0
      Adding synstructure v0.6.0
    Updating tempdir v0.3.7 -> v0.3.0
    Updating thread_local v1.0.1 -> v0.3.6
      Adding ucd-util v0.1.0
      Adding unicode-xid v0.0.4
      Adding utf8-ranges v1.0.1
      Adding version_check v0.1.4
    Updating walkdir v2.3.1 -> v2.2.5
    Updating which v2.0.1 -> v2.0.0
    Updating winapi v0.3.9 -> v0.3.0
    Updating winapi-i686-pc-windows-gnu v0.4.0 -> v0.3.0
    Updating winapi-util v0.1.5 -> v0.1.1
    Updating winapi-x86_64-pc-windows-gnu v0.4.0 -> v0.3.0
   Compiling semver-parser v0.7.0
   Compiling libc v0.2.45
    Checking rand_core v0.2.0
    Checking rand_core v0.3.0
    Checking odds v0.2.23
    Checking scopeguard v0.3.1
    Checking owning_ref v0.3.0
    Checking smallvec v0.6.10
   Compiling regex v1.0.5
    Checking crossbeam-utils v0.5.0
    Checking memoffset v0.2.0
    Checking same-file v1.0.3
    Checking regex-syntax v0.6.2
    Checking crossbeam-utils v0.6.0
    Checking walkdir v2.2.5
    Checking rand_xorshift v0.1.0
    Checking rand_hc v0.1.0
    Checking rand_isaac v0.1.0
    Checking lock_api v0.1.0
   Compiling semver v0.6.0
error[E0407]: method `seed_from_u64` is not a member of trait `SeedableRng`
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac.rs:126:5
    |
126 | /     fn seed_from_u64(seed: u64) -> Self {
127 | |         IsaacRng(BlockRng::<IsaacCore>::seed_from_u64(seed))
128 | |     }
    | |_____^ not a member of trait `SeedableRng`

error[E0407]: method `seed_from_u64` is not a member of trait `SeedableRng`
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac.rs:331:5
    |
331 | /     fn seed_from_u64(seed: u64) -> Self {
332 | |         let mut key = [w(0); RAND_SIZE];
333 | |         key[0] = w(seed as u32);
334 | |         key[1] = w((seed >> 32) as u32);
...   |
341 | |         Self::init(key, 1)
342 | |     }
    | |_____^ not a member of trait `SeedableRng`

error[E0407]: method `seed_from_u64` is not a member of trait `SeedableRng`
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac64.rs:116:5
    |
116 | /     fn seed_from_u64(seed: u64) -> Self {
117 | |         Isaac64Rng(BlockRng64::<Isaac64Core>::seed_from_u64(seed))
118 | |     }
    | |_____^ not a member of trait `SeedableRng`

error[E0407]: method `seed_from_u64` is not a member of trait `SeedableRng`
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac64.rs:301:5
    |
301 | /     fn seed_from_u64(seed: u64) -> Self {
302 | |         let mut key = [w(0); RAND_SIZE];
303 | |         key[0] = w(seed);
304 | |         // Initialize with only one pass.
...   |
310 | |         Self::init(key, 1)
311 | |     }
    | |_____^ not a member of trait `SeedableRng`

    Checking nodrop v0.1.8
error[E0599]: no function or associated item named `seed_from_u64` found for struct `BlockRng<IsaacCore>` in the current scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac.rs:127:41
    |
127 |         IsaacRng(BlockRng::<IsaacCore>::seed_from_u64(seed))
    |                                         ^^^^^^^^^^^^^ function or associated item not found in `BlockRng<IsaacCore>`

error[E0599]: no function or associated item named `seed_from_u64` found for struct `IsaacRng` in the current scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac.rs:141:15
    |
94  | pub struct IsaacRng(BlockRng<IsaacCore>);
    | ----------------------------------------- function or associated item `seed_from_u64` not found for this
...
141 |         Self::seed_from_u64(seed)
    |               ^^^^^^^^^^^^^
    |               |
    |               function or associated item not found in `IsaacRng`
    |               help: there is an associated function with a similar name: `new_from_u64`

error[E0599]: no function or associated item named `seed_from_u64` found for struct `BlockRng64<Isaac64Core>` in the current scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac64.rs:117:47
    |
117 |         Isaac64Rng(BlockRng64::<Isaac64Core>::seed_from_u64(seed))
    |                                               ^^^^^^^^^^^^^ function or associated item not found in `BlockRng64<Isaac64Core>`

error[E0599]: no function or associated item named `seed_from_u64` found for struct `Isaac64Rng` in the current scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac64.rs:131:15
    |
84  | pub struct Isaac64Rng(BlockRng64<Isaac64Core>);
    | ----------------------------------------------- function or associated item `seed_from_u64` not found for this
...
131 |         Self::seed_from_u64(seed)
    |               ^^^^^^^^^^^^^
    |               |
    |               function or associated item not found in `Isaac64Rng`
    |               help: there is an associated function with a similar name: `new_from_u64`

    Checking arrayvec v0.4.0
error[E0599]: no function or associated item named `seed_from_u64` found for struct `Isaac64Core` in the current scope
   --> /home/lo48576/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_isaac-0.1.0/src/isaac64.rs:283:15
    |
138 | pub struct Isaac64Core {
    | ---------------------- function or associated item `seed_from_u64` not found for this
...
283 |         Self::seed_from_u64(seed)
    |               ^^^^^^^^^^^^^
    |               |
    |               function or associated item not found in `Isaac64Core`
    |               help: there is an associated function with a similar name: `new_from_u64`

error: aborting due to 9 previous errors

Some errors have detailed explanations: E0407, E0599.
For more information about an error, try `rustc --explain E0407`.
error: could not compile `rand_isaac`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
</details>